### PR TITLE
Issue#7: Fixed shared isEditable state bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,4 +19,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug-fixes:
 
+- [Issue #7](https://github.com/RexBasiliscus/cv-application/issues/7) Fixed the bug where state was shared between form components
 - [Issue #8](https://github.com/RexBasiliscus/cv-application/issues/8) Fixed where the form wasn't showing the correct default date

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,60 +1,19 @@
-import { useEffect, useState } from 'react'
-import GeneralInfo from './components/GeneralInfo'
-import Education from './components/Education'
-import { getPersonFromSessionStorage, getEducationFromSessionStorage } from './utilities/getFromSessionStorage'
+import GeneralInfo from "./components/GeneralInfo";
+import Education from "./components/Education";
 
 function App() {
-  const [person, setPerson] = useState(getPersonFromSessionStorage())
-  const [education, setEducation] = useState(getEducationFromSessionStorage())
-  const [isEditable, setIsEditable] = useState(true)
-
-  useEffect(() => {
-    sessionStorage.setItem("person", JSON.stringify(person))
-    sessionStorage.setItem("education", JSON.stringify(education))
-  }, [person, education])
-
-  // useEffect(() => {
-  //   sessionStorage.setItem("education", JSON.stringify(education))
-  // }, [education])
-
-  const handleInputChange = (e) => {
-    const { name, value } = e.target
-
-    if (name in person) {
-      setPerson({ ...person, [name]: value })
-    } else if (name in education) {
-      setEducation({ ...education, [name]: value })
-    }
-  }
-
-  const handleSubmit = (e) => {
-    // e.preventDefault()
-    console.log('Form submitted.')
-    setIsEditable(false)
-  }
-
   return (
     <>
       <header>
         <h1>CV Application Creator</h1>
       </header>
 
-        <div>
-          <GeneralInfo 
-            person={person} 
-            handleInputChange={handleInputChange} 
-            onClick={() => setIsEditable(true)}
-            handleSubmit={handleSubmit}
-            isEditable={isEditable} />
-          <Education 
-            education={education}
-            handleInputChange={handleInputChange}
-            onClick={() => setIsEditable(true)}
-            handleSubmit={handleSubmit}
-            isEditable={isEditable} /> 
-        </div>
+      <div>
+        <GeneralInfo />
+        <Education />
+      </div>
     </>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/components/Education.jsx
+++ b/src/components/Education.jsx
@@ -1,42 +1,76 @@
-import { keyToDisplayName, keyToDisplayType } from '../utilities/keyToDisplay'
+import { keyToDisplayName, keyToDisplayType } from "../utilities/keyToDisplay";
+import { getEducationFromSessionStorage } from "../utilities/getFromSessionStorage";
+import { useState, useEffect } from "react";
 
-const Education = ({ handleInputChange, education, isEditable, onClick, handleSubmit }) => {
-  const educationArr = Object.entries(education)
-  // console.log(educationArr)
+const Education = () => {
+  const [education, setEducation] = useState(getEducationFromSessionStorage());
+  const [isEditable, setIsEditable] = useState(true);
+
+  useEffect(() => {
+    sessionStorage.setItem("education", JSON.stringify(education));
+  }, [education]);
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+
+    if (name in education) {
+      setEducation({ ...education, [name]: value });
+    }
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    console.log("Form submitted.");
+    setIsEditable(false);
+  };
+
+  const educationArr = Object.entries(education);
+  // console.log(educationArr);
 
   return (
     <section className="education__info">
       <h2>Education</h2>
       <div className="education__wrapper">
-        <form className="form__education" onSubmit={handleSubmit}>
+        <form
+          className="form__education"
+          onSubmit={handleSubmit}
+        >
           {educationArr.map(([key, value]) => (
-              <div className="input-field" key={key}>
-                <label htmlFor={key}>{keyToDisplayName[key]}: </label>
-                <input 
-                  name={key}
-                  type={keyToDisplayType[key]}
-                  {...isEditable ? ({ required: "required " }) : ({ disabled: "disabled" })}
-                  placeholder={`Please type in your ${keyToDisplayName[key]}`} 
-                  value={value}
-                  onChange={handleInputChange}
-                  />
-              </div>
-            ))}
-            {isEditable ? 
-              <input 
-                className="save-btn" 
-                type="submit" 
-                value="Save" /> :
-              <button 
-                className="edit-btn"
-                onClick={onClick}>
-                  Edit
-              </button>
-            }
+            <div
+              className="input-field"
+              key={key}
+            >
+              <label htmlFor={key}>{keyToDisplayName[key]}: </label>
+              <input
+                name={key}
+                type={keyToDisplayType[key]}
+                {...(isEditable
+                  ? { required: "required " }
+                  : { disabled: "disabled" })}
+                placeholder={`Please type in your ${keyToDisplayName[key]}`}
+                value={value}
+                onChange={handleInputChange}
+              />
+            </div>
+          ))}
+          {isEditable ? (
+            <input
+              className="save-btn"
+              type="submit"
+              value="Save"
+            />
+          ) : (
+            <button
+              className="edit-btn"
+              onClick={() => setIsEditable(true)}
+            >
+              Edit
+            </button>
+          )}
         </form>
       </div>
     </section>
-  )
-}
+  );
+};
 
-export default Education
+export default Education;

--- a/src/components/GeneralInfo.jsx
+++ b/src/components/GeneralInfo.jsx
@@ -1,43 +1,78 @@
-import { keyToDisplayName, keyToDisplayType } from '../utilities/keyToDisplay'
+import { keyToDisplayName, keyToDisplayType } from "../utilities/keyToDisplay";
+import { getPersonFromSessionStorage } from "../utilities/getFromSessionStorage";
+import { useState, useEffect } from "react";
 
-const GeneralInfo = ({ handleInputChange, person, handleSubmit, isEditable, onClick }) => {
+const GeneralInfo = () => {
+  const [person, setPerson] = useState(getPersonFromSessionStorage());
+  const [isEditable, setIsEditable] = useState(true);
 
-  const personArr = Object.entries(person)
-  // console.log(personArr)
+  const personArr = Object.entries(person);
+  // console.log(personArr);
 
+  useEffect(() => {
+    sessionStorage.setItem("person", JSON.stringify(person));
+  }, [person]);
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+
+    if (name in person) {
+      setPerson({ ...person, [name]: value });
+    }
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    console.log("Form submitted.");
+    setIsEditable(false);
+  };
 
   return (
     <section className="general__info">
-        <h2>General Information</h2>
-        <form className="form__general" onSubmit={handleSubmit} >
-          {personArr.map(([key, value]) => (
-            <div className="input-field" key={key}>
-              <label htmlFor={key}>{keyToDisplayName[key]}: </label>
-              <input 
-                name={key}
-                type={keyToDisplayType[key]}
-                {...(key === "phone" && { pattern: "[0-9]{9}", title: "Please enter a 9-digit phone number" })}
-                {...(isEditable ? { required: "required" } : { disabled: "disabled" })}
-                placeholder={`Please type in your ${keyToDisplayName[key]}`} 
-                value={value}
-                onChange={handleInputChange}
-                />
-            </div>
-          ))}
-            {isEditable ? 
-              <input 
-                className="save-btn" 
-                type="submit" 
-                value="Save" /> :
-              <button 
-                className="edit-btn"
-                onClick={onClick}>
-                  Edit
-              </button>
-            }
-        </form>
-      </section>
-  )
-}
+      <h2>General Information</h2>
+      <form
+        className="form__general"
+        onSubmit={handleSubmit}
+      >
+        {personArr.map(([key, value]) => (
+          <div
+            className="input-field"
+            key={key}
+          >
+            <label htmlFor={key}>{keyToDisplayName[key]}: </label>
+            <input
+              name={key}
+              type={keyToDisplayType[key]}
+              {...(key === "phone" && {
+                pattern: "[0-9]{9}",
+                title: "Please enter a 9-digit phone number",
+              })}
+              {...(isEditable
+                ? { required: "required" }
+                : { disabled: "disabled" })}
+              placeholder={`Please type in your ${keyToDisplayName[key]}`}
+              value={value}
+              onChange={handleInputChange}
+            />
+          </div>
+        ))}
+        {isEditable ? (
+          <input
+            className="save-btn"
+            type="submit"
+            value="Save"
+          />
+        ) : (
+          <button
+            className="edit-btn"
+            onClick={() => setIsEditable(true)}
+          >
+            Edit
+          </button>
+        )}
+      </form>
+    </section>
+  );
+};
 
-export default GeneralInfo
+export default GeneralInfo;


### PR DESCRIPTION
Fixed the bug where both forms shared the isEditable state. See [Issue#7](https://github.com/RexBasiliscus/cv-application/issues/7)

**This was the bug:**
After typing info in one form and then clicking on the Save button, that form should change its isEditable state into false, making the input fields "locked" (disabled attribute) and the Save button should change into the Edit button. The other form(s) should be unaffected by this action.
In the current case, where the state is shared (state is in the App.jsx component, then passed through props to its child components), all the forms are "locked" after pressing any Save button.

**Fix:**
I have made each component have independent logic, so each component now has its own object state, isEditable state and its own handler functions with specific logic, so data isn't shared between components. The parent App component now only links the child components on the same page.

**Working changes:**
By submitting the first form, only it becomes locked (att. disabled), while the second is still editable.
![image](https://github.com/RexBasiliscus/cv-application/assets/56839682/190934f8-69f8-4ef9-8677-0b454808856e)
